### PR TITLE
hide dot pointers if not enough images for sliding

### DIFF
--- a/src/ngx-carousel/ngx-carousel.component.ts
+++ b/src/ngx-carousel/ngx-carousel.component.ts
@@ -402,7 +402,9 @@ export class NgxCarouselComponent
       }
     }
 
-    this.pointNumbers = pointers;
+    // if there are only one "page" with slides - hide dot pointers
+    this.pointNumbers = pointers.length > 1 ? pointers : [];
+
     this.carouselPointActiver();
     if (this.pointIndex <= 1) {
       this.btnBoolean(1, 1);


### PR DESCRIPTION
made PR for removing dot if all existing slides are placed in carousel space(no option to scroll). In my project i need to hide it in specified case and i decided, that it can be useful for someone else.

![slider](https://user-images.githubusercontent.com/13203777/37726719-aff9f560-2d3e-11e8-8a7e-f519b926829e.png)
